### PR TITLE
 Added Features UI Scale setting and set per SCENE

### DIFF
--- a/AnyRes/Handler.cs
+++ b/AnyRes/Handler.cs
@@ -31,9 +31,7 @@ namespace AnyRes
                     LastSetRes = files[0].node;
                 }
             }
-
-            if (initial & LastSetRes != null)
-
+            if (initial && LastSetRes != null)
             {
                 AnyRes.SetScreenRes(LastSetRes, false);
             }

--- a/GameData/AnyRes/PluginData/EDITOR.cfg
+++ b/GameData/AnyRes/PluginData/EDITOR.cfg
@@ -1,5 +1,0 @@
-name = EDITOR
-x = 1920
-y = 1080
-fullscreen = true
-scale = 1.0

--- a/GameData/AnyRes/PluginData/FLIGHT.cfg
+++ b/GameData/AnyRes/PluginData/FLIGHT.cfg
@@ -1,5 +1,0 @@
-name = FLIGHT
-x = 1920
-y = 1080
-fullscreen = true
-scale = 1.0

--- a/GameData/AnyRes/PluginData/SPACECENTER.cfg
+++ b/GameData/AnyRes/PluginData/SPACECENTER.cfg
@@ -1,5 +1,0 @@
-name = SPACECENTER
-x = 1920
-y = 1080
-fullscreen = true
-scale = 1.0

--- a/GameData/AnyRes/PluginData/TRACKSTATION.cfg
+++ b/GameData/AnyRes/PluginData/TRACKSTATION.cfg
@@ -1,5 +1,0 @@
-name = TRACKSTATION
-x = 1920
-y = 1080
-fullscreen = true
-scale = 1.0


### PR DESCRIPTION
It can now automatically switch resolution and UI scale based on scene. Each setting config now includes a "scale" attribute in addition to name, height, width and fullscreen.
All it needs is a config file (auto created on first run) with the scene name (e.g. 'EDITOR', 'FLIGHT', etc.).
The UI Window updates after each action and allows to save by preset or SCENE.  So saving and/or apply new presets is easier.